### PR TITLE
Ported to 1.9.4 (Works on both 1.9.0 and 1.9.4)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-
-// For those who want the bleeding edge
 buildscript {
     repositories {
         jcenter()
@@ -9,73 +7,34 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
     }
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-/*
-// for people who want stable - not yet functional for MC 1.8.8 - we require the forgegradle 2.1 snapshot
-plugins {
-    id "net.minecraftforge.gradle.forge" version "2.0.2"
-}
-*/
-version = "1.0"
-group= "com.qkninja.clockhud" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+version = "${minecraft_version}-${mod_version}"
+group= "com.qkninja.clockhud"
 archivesBaseName = "ClockHUD"
 
 minecraft {
-    version = "1.8.8-11.15.0.1628-1.8.8"
+    version = "${minecraft_version}-${forge_version}"
     runDir = "run"
-    
-    // the mappings can be changed at any time, and must be in the following format.
-    // snapshot_YYYYMMDD   snapshot are built nightly.
-    // stable_#            stables are built at the discretion of the MCP team.
-    // Use non-default mappings at your own risk. they may not always work.
-    // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20151122"
-    // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
-}
-
-dependencies {
-    // you may put jars on which you depend on in ./libs
-    // or you may define them like so..
-    //compile "some.group:artifact:version:classifier"
-    //compile "some.group:artifact:version"
-      
-    // real examples
-    //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
-    //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
-
-    // the 'provided' configuration is for optional dependencies that exist at compile-time but might not at runtime.
-    //provided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // the deobf configurations:  'deobfCompile' and 'deobfProvided' are the same as the normal compile and provided,
-    // except that these dependencies get remapped to your current MCP mappings
-    //deobfCompile 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-    //deobfProvided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // for more info...
-    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
-    // http://www.gradle.org/docs/current/userguide/dependency_management.html
-
+    mappings = "${mappings_version}"
+	
+    replace "@VERSION@", project.mod_version
+    replaceIn "Reference.java"
 }
 
 processResources
 {
-    // this will ensure that this task is redone when the versions change.
     inputs.property "version", project.version
     inputs.property "mcversion", project.minecraft.version
 
-    // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
-        include 'mcmod.info'
-                
-        // replace version and mcversion
+        include 'mcmod.info'                
         expand 'version':project.version, 'mcversion':project.minecraft.version
     }
         
-    // copy everything else, thats not the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+mod_version=1.3.0
+minecraft_version=1.9.4
+forge_version=12.17.0.1910-1.9.4
+mappings_version=snapshot_20160518

--- a/src/main/java/com/qkninja/clockhud/ClockHUD.java
+++ b/src/main/java/com/qkninja/clockhud/ClockHUD.java
@@ -13,12 +13,10 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 /**
  * A simple clock GUI to make telling the time easier.
  * @author QKninja
- * @version 1.7.10-1.0
  */
-@Mod(modid = Reference.MOD_ID, name = Reference.MOD_NAME, version = Reference.VERSION, guiFactory = Reference.GUI_FACTORY_CLASS)
+@Mod(modid = Reference.MOD_ID, name = Reference.MOD_NAME, version = Reference.MOD_VERSION, acceptedMinecraftVersions="[1.9,1.10)", guiFactory = Reference.GUI_FACTORY_CLASS)
 public class ClockHUD
 {
-
     @Mod.Instance(Reference.MOD_ID)
     public static ClockHUD instance;
 
@@ -41,5 +39,4 @@ public class ClockHUD
 
         MinecraftForge.EVENT_BUS.register(new KeyInputEventHandler());
     }
-
 }

--- a/src/main/java/com/qkninja/clockhud/client/gui/GuiClock.java
+++ b/src/main/java/com/qkninja/clockhud/client/gui/GuiClock.java
@@ -5,11 +5,11 @@ import com.qkninja.clockhud.reference.Reference;
 import com.qkninja.clockhud.reference.Textures;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import org.lwjgl.opengl.GL11;
 
 /**
  * Creates the Clock Gui.
@@ -22,7 +22,6 @@ public class GuiClock extends Gui
     public GuiClock(Minecraft mc)
     {
         super();
-
         this.mc = mc;
     }
 
@@ -36,16 +35,15 @@ public class GuiClock extends Gui
     @SubscribeEvent(priority = EventPriority.NORMAL)
     public void onRenderExperienceBar(RenderGameOverlayEvent.Post event)
     {
-
         if (!ConfigValues.guiActive || event.isCancelable() ||
-                event.type != RenderGameOverlayEvent.ElementType.EXPERIENCE)
+                event.getType() != RenderGameOverlayEvent.ElementType.EXPERIENCE)
         {
             return;
         }
 
         this.mc.getTextureManager().bindTexture(Textures.Gui.HUD);
 
-        GL11.glScalef(ConfigValues.scale, ConfigValues.scale, ConfigValues.scale);
+        GlStateManager.scale(ConfigValues.scale, ConfigValues.scale, ConfigValues.scale);
 
         this.drawTexturedModalRect(ConfigValues.xCoord + SUN_WIDTH / 2 - (DOT / 2),
                 ConfigValues.yCoord + ICON_HEIGHT / 2 - BAR_HEIGHT / 2, 0, 0, BAR_LENGTH, BAR_HEIGHT);
@@ -56,7 +54,7 @@ public class GuiClock extends Gui
             this.drawTexturedModalRect(ConfigValues.xCoord + (SUN_WIDTH - MOON_WIDTH) / 2 + getScaledTime(),
                     ConfigValues.yCoord, SUN_WIDTH, BAR_HEIGHT, MOON_WIDTH, ICON_HEIGHT);
 
-        GL11.glScalef(1 / ConfigValues.scale, 1 / ConfigValues.scale, 1 / ConfigValues.scale);
+        GlStateManager.scale(1 / ConfigValues.scale, 1 / ConfigValues.scale, 1 / ConfigValues.scale);
     }
 
     private int getScaledTime()

--- a/src/main/java/com/qkninja/clockhud/client/gui/GuiDayCount.java
+++ b/src/main/java/com/qkninja/clockhud/client/gui/GuiDayCount.java
@@ -5,10 +5,10 @@ import com.qkninja.clockhud.reference.Reference;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import org.lwjgl.opengl.GL11;
 
 /**
  * Renders the day count on the screen after each new day.
@@ -38,8 +38,7 @@ public class GuiDayCount extends Gui
     @SubscribeEvent(priority = EventPriority.NORMAL)
     public void onRenderExperienceBar(RenderGameOverlayEvent.Post event)
     {
-
-        if (ConfigValues.showDayCount && event.type == RenderGameOverlayEvent.ElementType.EXPERIENCE &&
+        if (ConfigValues.showDayCount && event.getType() == RenderGameOverlayEvent.ElementType.EXPERIENCE &&
                 (isRunning || isNewDay()))
         {
             long currentTime = Minecraft.getSystemTime();
@@ -53,8 +52,8 @@ public class GuiDayCount extends Gui
             float scaleFactor = getScaleFactor((endAnimationTime - currentTime) / (float) ANIMATION_TIME);
             String dayString = formDayString();
 
-            GL11.glScalef(scaleFactor, scaleFactor, scaleFactor);
-            GL11.glColor4f(1.0F, 1.0F, 1.0F, getOpacityFactor((endAnimationTime - currentTime) / (float) ANIMATION_TIME));
+            GlStateManager.scale(scaleFactor, scaleFactor, scaleFactor);
+            GlStateManager.color(1.0F, 1.0F, 1.0F, getOpacityFactor((endAnimationTime - currentTime) / (float) ANIMATION_TIME));
 
             ScaledResolution scaled = new ScaledResolution(mc);
 
@@ -64,8 +63,8 @@ public class GuiDayCount extends Gui
                     scaled.getScaledHeight() / 7 / scaleFactor,
                     0xffffff, false);
 
-            GL11.glScalef(1 / scaleFactor, 1 / scaleFactor, 1 / scaleFactor); // set scale to previous value
-            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+            GlStateManager.scale(1 / scaleFactor, 1 / scaleFactor, 1 / scaleFactor); // set scale to previous value
+            GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 
 
             if (currentTime >= endAnimationTime)

--- a/src/main/java/com/qkninja/clockhud/client/gui/GuiFactory.java
+++ b/src/main/java/com/qkninja/clockhud/client/gui/GuiFactory.java
@@ -1,8 +1,8 @@
 package com.qkninja.clockhud.client.gui;
 
-import net.minecraftforge.fml.client.IModGuiFactory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.fml.client.IModGuiFactory;
 
 import java.util.Set;
 

--- a/src/main/java/com/qkninja/clockhud/client/gui/ModGuiConfig.java
+++ b/src/main/java/com/qkninja/clockhud/client/gui/ModGuiConfig.java
@@ -2,10 +2,10 @@ package com.qkninja.clockhud.client.gui;
 
 import com.qkninja.clockhud.handler.ConfigurationHandler;
 import com.qkninja.clockhud.reference.Reference;
-import net.minecraftforge.fml.client.config.GuiConfig;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraftforge.common.config.ConfigElement;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.client.config.GuiConfig;
 
 public class ModGuiConfig extends GuiConfig
 {

--- a/src/main/java/com/qkninja/clockhud/client/handler/KeyInputEventHandler.java
+++ b/src/main/java/com/qkninja/clockhud/client/handler/KeyInputEventHandler.java
@@ -11,7 +11,7 @@ public class KeyInputEventHandler
 
     private static Key getPressedKeyBinding()
     {
-        if (KeyBindings.toggle.isPressed())
+        if (KeyBindings.TOGGLE.isPressed())
             return Key.TOGGLE;
         else return Key.UNKNOWN;
     }

--- a/src/main/java/com/qkninja/clockhud/client/settings/KeyBindings.java
+++ b/src/main/java/com/qkninja/clockhud/client/settings/KeyBindings.java
@@ -6,5 +6,5 @@ import org.lwjgl.input.Keyboard;
 
 public class KeyBindings
 {
-    public static KeyBinding toggle = new KeyBinding(Names.Keys.TOGGLE, Keyboard.KEY_COMMA, Names.Keys.CATEGORY);
+    public static final KeyBinding TOGGLE = new KeyBinding(Names.Keys.TOGGLE, Keyboard.KEY_COMMA, Names.Keys.CATEGORY);
 }

--- a/src/main/java/com/qkninja/clockhud/handler/ConfigurationHandler.java
+++ b/src/main/java/com/qkninja/clockhud/handler/ConfigurationHandler.java
@@ -2,9 +2,9 @@ package com.qkninja.clockhud.handler;
 
 import com.qkninja.clockhud.reference.ConfigValues;
 import com.qkninja.clockhud.reference.Reference;
+import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.common.config.Configuration;
 
 import java.io.File;
 
@@ -16,7 +16,7 @@ public class ConfigurationHandler
     {
         if (configuration == null)
         {
-            configuration =new Configuration(configFile);
+            configuration = new Configuration(configFile);
             loadConfiguration();
         }
     }
@@ -37,7 +37,7 @@ public class ConfigurationHandler
     @SubscribeEvent
     public void onConfigurationChangedEvent(ConfigChangedEvent.OnConfigChangedEvent event)
     {
-        if (event.modID.equalsIgnoreCase(Reference.MOD_ID))
+        if (event.getModID().equalsIgnoreCase(Reference.MOD_ID))
         {
             loadConfiguration();
         }

--- a/src/main/java/com/qkninja/clockhud/proxy/ClientProxy.java
+++ b/src/main/java/com/qkninja/clockhud/proxy/ClientProxy.java
@@ -3,9 +3,9 @@ package com.qkninja.clockhud.proxy;
 import com.qkninja.clockhud.client.gui.GuiClock;
 import com.qkninja.clockhud.client.gui.GuiDayCount;
 import com.qkninja.clockhud.client.settings.KeyBindings;
-import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
 
 public class ClientProxy extends CommonProxy
 {
@@ -21,6 +21,6 @@ public class ClientProxy extends CommonProxy
 
     public void registerKeyBindings()
     {
-        ClientRegistry.registerKeyBinding(KeyBindings.toggle);
+        ClientRegistry.registerKeyBinding(KeyBindings.TOGGLE);
     }
 }

--- a/src/main/java/com/qkninja/clockhud/proxy/CommonProxy.java
+++ b/src/main/java/com/qkninja/clockhud/proxy/CommonProxy.java
@@ -1,8 +1,5 @@
 package com.qkninja.clockhud.proxy;
 
-/**
- * Created by Sam on 2014-12-20.
- */
 public abstract class CommonProxy implements IProxy
 {
 

--- a/src/main/java/com/qkninja/clockhud/reference/Reference.java
+++ b/src/main/java/com/qkninja/clockhud/reference/Reference.java
@@ -2,9 +2,9 @@ package com.qkninja.clockhud.reference;
 
 public class Reference
 {
-    public static final String MOD_ID = "ClockHUD";
+    public static final String MOD_ID = "clockhud";
     public static final String MOD_NAME = "ClockHUD";
-    public static final String VERSION = "1.7.10-1.0";
+    public static final String MOD_VERSION = "@VERSION@";
     public static final String SERVER_PROXY_CLASS = "com.qkninja.clockhud.proxy.ServerProxy";
     public static final String CLIENT_PROXY_CLASS = "com.qkninja.clockhud.proxy.ClientProxy";
     public static final String GUI_FACTORY_CLASS = "com.qkninja.clockhud.client.gui.GuiFactory";

--- a/src/main/java/com/qkninja/clockhud/reference/Textures.java
+++ b/src/main/java/com/qkninja/clockhud/reference/Textures.java
@@ -3,9 +3,6 @@ package com.qkninja.clockhud.reference;
 import com.qkninja.clockhud.utility.ResourceLocationHelper;
 import net.minecraft.util.ResourceLocation;
 
-/**
- * Created by Sam on 2014-12-20.
- */
 public class Textures
 {
     public static final String RESOURCE_PREFIX = Reference.MOD_ID.toLowerCase() + ":";

--- a/src/main/java/com/qkninja/clockhud/utility/ResourceLocationHelper.java
+++ b/src/main/java/com/qkninja/clockhud/utility/ResourceLocationHelper.java
@@ -3,9 +3,6 @@ package com.qkninja.clockhud.utility;
 import com.qkninja.clockhud.reference.Reference;
 import net.minecraft.util.ResourceLocation;
 
-/**
- * Created by Sam on 2014-12-20.
- */
 public class ResourceLocationHelper
 {
     public static ResourceLocation getResourceLocation(String modId, String path)

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,10 +1,10 @@
 [
 {
-  "modid": "ClockHUD",
+  "modid": "clockhud",
   "name": "Clock HUD",
   "description": "A simple clock GUI to check the time.",
-  "version": "1.7.0-1.0",
-  "mcversion": "1.7.10",
+  "version": "${version}",
+  "mcversion": "${mcversion}",
   "url": "",
   "updateUrl": "",
   "authorList": [ "QKninja" ],


### PR DESCRIPTION
Changes:
Changed mod id to lower case (Mod IDs should ALWAYS be lower case)
Moved to GLStateManger instead of GL11
Improved buildscript. You only ever have to change versions in the gradle.properties file, to change your mod version, update Forge etc.